### PR TITLE
BUG: Use str(e) instead of deprecated e.message

### DIFF
--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -95,6 +95,7 @@ class S3Mixin(object):
             key.close()
         return key
 
+    @check_s3_connection
     @memoize
     def get_bucket(self, bucket_name):
         """
@@ -116,7 +117,7 @@ class S3Mixin(object):
             # all ValueErrors here.
             dot_msg = ("doesn't match either of '*.s3.amazonaws.com',"
                        " 's3.amazonaws.com'")
-            if dot_msg in e.message:
+            if dot_msg in str(e):
                 self.s3_conn = (
                     self.get_s3_connection(ordinary_calling_fmt=True))
                 bucket = self.s3_conn.get_bucket(bucket_name)

--- a/shiftmanager/tests/conftest.py
+++ b/shiftmanager/tests/conftest.py
@@ -83,4 +83,5 @@ def shift(monkeypatch, mock_connection, mock_s3):
     shift = rs.Redshift("", "", "", "",
                         aws_access_key_id="access_key",
                         aws_secret_access_key="secret_key")
+    shift.s3_conn = mock_s3
     return shift

--- a/shiftmanager/tests/test_s3.py
+++ b/shiftmanager/tests/test_s3.py
@@ -11,6 +11,7 @@ import json
 import os
 
 from mock import ANY
+import pytest
 
 
 def cleaned(statement):
@@ -72,6 +73,16 @@ def test_chunk_json_slices(shift, json_data, tmpdir):
         with shift.chunked_json_slices(data, slices, dpath) as (stamp, paths):
             assert len(paths) == slices
             chunk_checker(paths)
+
+
+def test_get_bucket(shift):
+    def raise_error(*args):
+        raise ValueError("doesn't match either of '*.s3.amazonaws.com',"
+                         " 's3.amazonaws.com'")
+    shift.get_s3_connection()
+    shift.s3_conn.get_bucket.side_effect = raise_error
+    with pytest.raises(ValueError):
+        shift.get_bucket("bucket.with.dots")
 
 
 def check_key_calls(s3keys, slices):


### PR DESCRIPTION
Reported by Andrew Harris. When python3 is used, the following exception could be raised:
```
    117             dot_msg = ("doesn't match either of '*.s3.amazonaws.com',"
    118                        " 's3.amazonaws.com'")
--> 119             if dot_msg in e.message:
    120                 self.s3_conn = (
    121                     self.get_s3_connection(ordinary_calling_fmt=True))

AttributeError: 'ValueError' object has no attribute 'message'
```

This should fix that problem.

cc @wrobstory @meli-lewis