### PR TITLE
mogrify method should return a str for python 3 compatibility

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.2.4'
+version = '0.2.5'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story']
 authors_string = ', '.join(authors)

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -97,4 +97,4 @@ class Redshift(AdminMixin, ReflectionMixin, S3Mixin):
         with self.connection as conn:
             with conn.cursor() as curs:
                 mogrified = curs.mogrify(batch, parameters)
-        return mogrified
+        return mogrified.decode('utf-8')


### PR DESCRIPTION
Got the following traceback with Python 3:
```
In [5]: dev.create_user(user, password, execute=True, **user_kwargs)
Connecting to dev-data-pipeline.cuxrn97vbxid.us-east-1.redshift.amazonaws.com...
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/Users/jeffklukas/Code/shiftmanager-simple/shiftmanager_simple/__main__.py in <module>()
----> 1 dev.create_user(user, password, execute=True, **user_kwargs)

/Users/jeffklukas/Code/shiftmanager-simple/venv/lib/python3.4/site-packages/shiftmanager/mixins/admin.py in create_user(self, name, password, valid_until, createdb, createuser, groups, execute, **parameters)
     85             statement += " VALID UNTIL %(valid_until)s"
     86         if parameters:
---> 87             statement += ';\n' + self.alter_user(name, **parameters)
     88         return self.mogrify(statement, data, execute)
     89

TypeError: Can't convert 'bytes' object to str implicitly
```