### PR TITLE
Pr pg to redshift

### DIFF
--- a/shiftmanager/mixins/__init__.py
+++ b/shiftmanager/mixins/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
 from .admin import AdminMixin
+from .postgres import PostgresMixin
 from .reflection import ReflectionMixin
 from .s3 import S3Mixin

--- a/shiftmanager/mixins/admin.py
+++ b/shiftmanager/mixins/admin.py
@@ -140,5 +140,5 @@ class AdminMixin(object):
                 options.append("RESET %s" % param)
             else:
                 options.append("SET %s = %s" % (param, value))
-        statement += ', '.join(options)
+        statement += ' '.join(options)
         return self.mogrify(statement, data, execute)

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -142,6 +142,7 @@ class PostgresMixin(S3Mixin):
     def generate_copy_statement(self, table_name, manifest_key_path):
     # does the keypath have a complete bucket name and all?
     # write the rest of this function in the morning
+        pass
 
     def copy_table_to_redshift(self, table_name, bucket_name, key_prefix, slices, cleanup=True):
 
@@ -197,6 +198,7 @@ class PostgresMixin(S3Mixin):
             manifest = {'entries': manifest_entries}
             manifest_key_path = "".join([final_key_prefix,
                                          backfill_timestamp, ".manifest"])
+            from pprint import pprint;import pytest;pytest.set_trace()
             manifest_key = bucket.new_key(manifest_key_path)
             manifest_key.set_contents_from_string(json.dumps(manifest),
                                                   encrypt_key=True)

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -139,6 +139,10 @@ class PostgresMixin(S3Mixin):
         boto_key = bucket.new_key(s3_key_path)
         boto_key.set_contents_from_string(chunk, encrypt_key=True)
 
+    def generate_copy_statement(self, table_name, manifest_key_path):
+    # does the keypath have a complete bucket name and all?
+    # write the rest of this function in the morning
+
     def copy_table_to_redshift(self, table_name, bucket_name, key_prefix, slices, cleanup=True):
 
         """
@@ -160,6 +164,9 @@ class PostgresMixin(S3Mixin):
         cleanup: bool, default True
             Specifies whether data will remain in S3 after job completes
         """
+        if not self.table_exists(table_name):
+            raise ValueError("This table_name does not exist in Redshift!")
+
         bucket = self.get_bucket(bucket_name)
         if not key_prefix.endswith("/"):
             final_key_prefix = "".join([key_prefix, "/"])
@@ -193,7 +200,6 @@ class PostgresMixin(S3Mixin):
             manifest_key = bucket.new_key(manifest_key_path)
             manifest_key.set_contents_from_string(json.dumps(manifest),
                                                   encrypt_key=True)
-
 
 
 

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -136,7 +136,6 @@ class PostgresMixin(S3Mixin):
 
     def copy_table_to_redshift(self, pg_table_name, redshift_table_name,
                                bucket_name, key_prefix, slices):
-
         """
         Write the contents of a Postgres table to Redshift.
         Write the table to the given bucket under the given

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -9,8 +9,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from datetime import datetime
 import json
-import os
-from tempfile import mkstemp
+import tempfile
 
 import psycopg2
 
@@ -213,8 +212,8 @@ class PostgresMixin(S3Mixin):
         else:
             final_key_prefix = key_prefix
 
-        try:
-            fp, csv_temp_path = mkstemp()
+        with tempfile.NamedTemporaryFile() as ntf:
+            csv_temp_path = ntf.name
             row_count = self.pg_copy_table_to_csv(
                 csv_temp_path, pg_table_name=pg_table_name,
                 pg_select_statement=pg_select_statement)
@@ -265,7 +264,3 @@ class PostgresMixin(S3Mixin):
                 for key in all_s3_keys:
                     bucket.delete_key(key)
                 raise
-
-        finally:
-            os.close(fp)
-            os.remove(csv_temp_path)

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -10,9 +10,11 @@ from __future__ import (absolute_import, division, print_function,
 import psycopg2
 
 from shiftmanager.memoized_property import memoized_property
+from shiftmanager.mixins.s3 import S3Mixin
 from shiftmanager import util
 
-class PostgresMixin(object):
+
+class PostgresMixin(S3Mixin):
     """The Postgres interaction base class for `Redshift`."""
 
     @memoized_property
@@ -116,17 +118,20 @@ class PostgresMixin(object):
                     yield "".join(chunk_lines)
                     chunk_lines = []
 
-
-    def write_csv_chunk_to_S3(self, chunk, s3_key_path):
+    def write_csv_chunk_to_S3(self, chunk, bucket, s3_key_path):
         """
         Given a string chunk that represents a piece of a CSV file, write
-        the chunk to chunk_file_path
+        the chunk to a Boto s3 key
 
         Parameters
         ----------
         chunk: str
             String blob representing a chunk of a larger CSV.
-        s3_key_name:
+        bucket: boto.s3.bucket.Bucket
+            The bucket we're writing to
+        s3_key_path: str
             The key path to write the chunk to
         """
+        boto_key = bucket.new_key(s3_key_path)
+        boto_key.set_contents_from_string(chunk, encrypt_key=True)
         pass

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+"""
+Mixin classes for working with Postgres database exports
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import psycopg2
+
+from shiftmanager.memoized_property import memoized_property
+
+class PostgresMixin(object):
+    """The Postgres interaction base class for `Redshift`."""
+
+    @memoized_property
+    def pg_connection(self):
+        """A `psycopg2.connect` connection to Postgres.
+
+        Instantiation is delayed until the object is first used.
+        """
+        print("Connecting to %s..." % self.pg_host)
+        return psycopg2.connect(user=self.pg_user,
+                                host=self.pg_host,
+                                port=self.pg_port,
+                                database=self.pg_database,
+                                password=self.pg_password)
+
+    def get_postgres_connection(self, database=None, user=None, password=None,
+                                host=None, port=5432):
+        """
+        Create a `psycopg2.connect` connection to Redshift.
+        """
+
+        self.pg_user = user
+        self.pg_host = host
+        self.pg_port = port
+        self.pg_database = database
+        self.pg_password = password
+        return self.pg_connection
+
+    def copy_table_to_csv(self, table_name, csv_file_path):
+        """
+        Use Postgres to COPY the given table_name to a csv file at the given
+        csv_path.
+
+        Parameters
+        ----------
+        table_name: str
+            Table name to be written to CSV
+        csv_file_path: str
+            File path for the CSV to be written to by Postgres
+        """
+        pass
+
+    def get_csv_chunk_generator(self, csv_file_path, chunks):
+        """
+        Given the csv_file_path, split the CSV into chunks number of string
+        blobs.
+
+        Parameters
+        ----------
+        csv_file_path: str
+            File path for the CSV written by Postgres
+        chunks: int
+            Number of chunks to split the CSV file into
+        """
+        pass
+
+    def write_csv_chunk_to_S3(self, chunk, s3_key_path):
+        """
+        Given a string chunk that represents a piece of a CSV file, write
+        the chunk to chunk_file_path
+
+        Parameters
+        ----------
+        chunk: str
+            String blob representing a chunk of a larger CSV.
+        s3_key_name:
+            The key path to write the chunk to
+        """
+        pass

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -27,6 +27,12 @@ class PostgresMixin(object):
                                 database=self.pg_database,
                                 password=self.pg_password)
 
+    def execute_and_commit_single_statement(self, statement):
+        """Execute single Postgres statement"""
+        with self.pg_connection as conn:
+            with conn.cursor() as cur:
+                cur.execute(statement)
+
     def get_postgres_connection(self, database=None, user=None, password=None,
                                 host=None, port=5432):
         """
@@ -52,7 +58,10 @@ class PostgresMixin(object):
         csv_file_path: str
             File path for the CSV to be written to by Postgres
         """
-        pass
+        copy = "COPY {table_name} TO '{csv_file_path}' DELIMITER ',' CSV;"
+        formatted_statement = copy.format(table_name=table_name,
+                                          csv_file_path=csv_file_path)
+        self.execute_and_commit_single_statement(formatted_statement)
 
     def get_csv_chunk_generator(self, csv_file_path, chunks):
         """

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -37,10 +37,12 @@ def check_s3_connection(f):
 class S3Mixin(object):
     """The S3 interaction base class for `Redshift`."""
 
-    s3_conn = None
-    aws_access_key_id = None
-    aws_secret_access_key = None
-    security_token = None
+    def __init__(self, *args, **kwargs):
+
+        self.s3_conn = None
+        self.aws_access_key_id = None
+        self.aws_secret_access_key = None
+        self.security_token = None
 
     def set_aws_credentials(self, aws_access_key_id, aws_secret_access_key,
                             security_token=None):

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -15,7 +15,6 @@ from boto.s3.connection import S3Connection
 from boto.s3.connection import OrdinaryCallingFormat
 
 from shiftmanager import util, queries
-from shiftmanager.util import memoize
 
 
 def check_s3_connection(f):
@@ -72,11 +71,9 @@ class S3Mixin(object):
         # Amazon used to use the AWS_SECURITY_TOKEN, but is transitioning
         # to AWS_SESSION_TOKEN. boto2 still only supports the old version,
         # but we want to support both.
-        security_token = (
-                os.environ.get('AWS_SECURITY_TOKEN') or
-                os.environ.get('AWS_SESSION_TOKEN') or
-                self.security_token
-                )
+        security_token = (os.environ.get('AWS_SECURITY_TOKEN') or
+                          os.environ.get('AWS_SESSION_TOKEN') or
+                          self.security_token)
         if security_token:
             kwargs['security_token'] = security_token
 

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -120,8 +120,24 @@ class S3Mixin(object):
             key.close()
         return key
 
+    def write_string_to_s3(self, chunk, bucket, s3_key_path):
+        """
+        Given a string chunk that represents a piece of a CSV file, write
+        the chunk to an S3 key.
+
+        Parameters
+        ----------
+        chunk: str
+            String blob representing a chunk of a larger CSV
+        bucket: boto.s3.bucket.Bucket
+            The bucket to be written to
+        s3_key_path: str
+            The key path to write the chunk to
+        """
+        boto_key = bucket.new_key(s3_key_path)
+        boto_key.set_contents_from_string(chunk, encrypt_key=True)
+
     @check_s3_connection
-    # @memoize
     def get_bucket(self, bucket_name):
         """
         Get boto.s3.bucket. Caches existing buckets.

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -38,11 +38,7 @@ class S3Mixin(object):
     """The S3 interaction base class for `Redshift`."""
 
     def __init__(self, *args, **kwargs):
-
         self.s3_conn = None
-        self.aws_access_key_id = None
-        self.aws_secret_access_key = None
-        self.security_token = None
 
     def set_aws_credentials(self, aws_access_key_id, aws_secret_access_key,
                             security_token=None):

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -118,7 +118,6 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
                                 where tablename = '{}';""".format(table_name))
 
                 table = [row for row in curs]
-        from pprint import pprint;import pytest;pytest.set_trace()
 
         if table and table[0][0] == table_name:
             return True

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -10,11 +10,12 @@ import os
 
 import psycopg2
 
-from shiftmanager.mixins import (AdminMixin, ReflectionMixin, PostgresMixin)
+from shiftmanager.mixins import (AdminMixin, ReflectionMixin, PostgresMixin,
+                                 S3Mixin)
 from shiftmanager.memoized_property import memoized_property
 
 
-class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
+class Redshift(AdminMixin, ReflectionMixin, PostgresMixin, S3Mixin):
     """Interface to Redshift.
 
     This class will default to environment params for all arguments.

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -73,6 +73,8 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
 
         self._all_privileges = None
 
+        super(Redshift, self).__init__()
+
     def execute(self, batch, parameters=None):
         """
         Execute a batch of SQL statements using this instance's connection.
@@ -113,10 +115,10 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
         """
         with self.connection as conn:
             with conn.cursor() as cur:
-                cur.execute("""select distinct(tablename)
+                cur.execute("""select count (distinct tablename)
                                from pg_table_def
                                where tablename = '{}';""".format(table_name))
 
-                table = [row for row in cur]
+                table_count = cur.fetchone()[0]
 
-        return (table and table[0][0] == table_name)
+        return table_count == 1

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -10,11 +10,11 @@ import os
 
 import psycopg2
 
-from shiftmanager.mixins import AdminMixin, ReflectionMixin, S3Mixin
+from shiftmanager.mixins import (AdminMixin, ReflectionMixin, PostgresMixin)
 from shiftmanager.memoized_property import memoized_property
 
 
-class Redshift(AdminMixin, ReflectionMixin, S3Mixin):
+class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
     """Interface to Redshift.
 
     This class will default to environment params for all arguments.
@@ -64,7 +64,6 @@ class Redshift(AdminMixin, ReflectionMixin, S3Mixin):
 
         self.set_aws_credentials(aws_access_key_id, aws_secret_access_key,
                                  security_token)
-        self.s3_conn = None
 
         self.user = user or os.environ.get('PGUSER')
         self.host = host or os.environ.get('PGHOST')

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -87,15 +87,15 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
             Values to bind to the batch, passed to `cursor.execute`
         """
         with self.connection as conn:
-            with conn.cursor() as curs:
-                curs.execute(batch, parameters)
+            with conn.cursor() as cur:
+                cur.execute(batch, parameters)
 
     def mogrify(self, batch, parameters=None, execute=False):
         if execute:
             self.execute(batch, parameters)
         with self.connection as conn:
-            with conn.cursor() as curs:
-                mogrified = curs.mogrify(batch, parameters)
+            with conn.cursor() as cur:
+                mogrified = cur.mogrify(batch, parameters)
         return mogrified.decode('utf-8')
 
     def table_exists(self, table_name):
@@ -112,14 +112,11 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
         boolean
         """
         with self.connection as conn:
-            with conn.cursor() as curs:
-                curs.execute("""select distinct(tablename)
-                                from pg_table_def
-                                where tablename = '{}';""".format(table_name))
+            with conn.cursor() as cur:
+                cur.execute("""select distinct(tablename)
+                               from pg_table_def
+                               where tablename = '{}';""".format(table_name))
 
-                table = [row for row in curs]
+                table = [row for row in cur]
 
-        if table and table[0][0] == table_name:
-            return True
-        else:
-            return False
+        return (table and table[0][0] == table_name)

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -97,3 +97,29 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
             with conn.cursor() as curs:
                 mogrified = curs.mogrify(batch, parameters)
         return mogrified.decode('utf-8')
+
+    def table_exists(self, table_name):
+        """
+        Check Redshift for whether a table exists.
+
+        Parameters
+        ----------
+        table_name : str
+            The name of the table for whose existence we're checking
+
+        Returns
+        -------
+        boolean
+        """
+        with self.connection as conn:
+            with conn.cursor() as curs:
+                curs.execute("""select distinct(tablename)
+                                from pg_table_def
+                                where tablename = '{}';""".format(table_name))
+
+                table = [row for row in curs]
+
+        if table and table[0][0] == table_name:
+            return True
+        else:
+            return False

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -74,7 +74,7 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin, S3Mixin):
 
         self._all_privileges = None
 
-        super(Redshift, self).__init__()
+        S3Mixin.__init__(self)
 
     def execute(self, batch, parameters=None):
         """

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -118,6 +118,7 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin):
                                 where tablename = '{}';""".format(table_name))
 
                 table = [row for row in curs]
+        from pprint import pprint;import pytest;pytest.set_trace()
 
         if table and table[0][0] == table_name:
             return True

--- a/shiftmanager/tests/conftest.py
+++ b/shiftmanager/tests/conftest.py
@@ -102,7 +102,7 @@ def postgres(request, mock_s3):
     pg = sp.PostgresMixin()
     pg.s3_conn = mock_s3
     conn = pg.create_connection(database="shiftmanager",
-                                      user="shiftmanager")
+                                user="shiftmanager")
     cur = conn.cursor()
 
     # Just in case of an unclean exit

--- a/shiftmanager/tests/conftest.py
+++ b/shiftmanager/tests/conftest.py
@@ -20,11 +20,22 @@ def mock_connection():
 
     class MockCursor(object):
 
-        statements = []
-        return_rows = []
+        def __init__(self, *args, **kwargs):
+
+            self.statements = []
+            self.return_rows = []
+            self.cursor_position = 0
 
         def execute(self, statement, *args, **kwargs):
             self.statements.append(statement)
+
+        def fetchone(self, *args, **kwargs):
+            if self.cursor_position > len(self.return_rows) - 1:
+                return None
+            else:
+                next_row = self.return_rows[self.cursor_position]
+                self.cursor_position += 1
+                return next_row
 
         def __enter__(self, *args, **kwargs):
             return self

--- a/shiftmanager/tests/conftest.py
+++ b/shiftmanager/tests/conftest.py
@@ -114,7 +114,7 @@ def shift(monkeypatch, mock_connection, mock_s3):
 
 
 @pytest.fixture
-def postgres(monkeypatch, request, mock_connection, mock_s3):
+def postgres(monkeypatch, mock_connection, request, mock_s3):
     """
     Setup Postgres table with a few random columns of data for testing.
     Tear down table at end of text fixture context.

--- a/shiftmanager/tests/conftest.py
+++ b/shiftmanager/tests/conftest.py
@@ -23,7 +23,7 @@ def mock_connection():
         statements = []
         return_rows = []
 
-        def execute(self, statement):
+        def execute(self, statement, *args, **kwargs):
             self.statements.append(statement)
 
         def __enter__(self, *args, **kwargs):
@@ -134,8 +134,8 @@ def postgres(monkeypatch, mock_connection, request, mock_s3):
 
     pg = PostgresRedshift()
     pg.s3_conn = mock_s3
-    conn = pg.create_connection(database="shiftmanager",
-                                user="shiftmanager")
+    conn = pg.create_pg_connection(database="shiftmanager",
+                                   user="shiftmanager")
     cur = conn.cursor()
 
     # Just in case of an unclean exit

--- a/shiftmanager/tests/conftest.py
+++ b/shiftmanager/tests/conftest.py
@@ -101,7 +101,7 @@ def postgres(request, mock_s3):
 
     pg = sp.PostgresMixin()
     pg.s3_conn = mock_s3
-    conn = pg.get_postgres_connection(database="shiftmanager",
+    conn = pg.create_connection(database="shiftmanager",
                                       user="shiftmanager")
     cur = conn.cursor()
 

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Tests for PostgresMixin
+
+Test Runner: PyTest
+"""
+
+import psycopg2
+import pytest
+
+import shiftmanager.mixins.postgres as sp
+
+@pytest.fixture(scope="session")
+def postgres(request):
+    """
+    Setup Postgres table with a few random columns of data for testing.
+    Tear down table at end of text fixture context.
+    """
+
+    pg = sp.PostgresMixin()
+    conn = pg.get_postgres_connection(database="shiftmanager",
+                                      user="shiftmanager")
+    cur = conn.cursor()
+
+    create_query = """CREATE TABLE test_table (
+                          uuid char(36),
+                          number integer,
+                          name varchar(255));"""
+
+    cur.execute(create_query)
+    conn.commit()
+
+    def teardown_pg():
+        drop_query = "DROP TABLE test_table;"
+        cur.execute(drop_query)
+        conn.commit()
+        cur.close()
+        conn.close()
+
+    request.addfinalizer(teardown_pg)
+
+@pytest.mark.postgrestest
+def test_get_connection(postgres):
+    assert True is True

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -74,12 +74,26 @@ def test_write_chunk_to_s3(postgres, tmpdir):
 
 @pytest.mark.postgrestest
 def test_copy_table_to_redshift(postgres, tmpdir):
+    from pprint import pprint;import pytest;pytest.set_trace()
     postgres.copy_table_to_redshift("test_table", 'com.simple.postgres.mock',
                                     "/tmp/backfill/", 10)
 
     bucket = postgres.get_bucket('com.simple.postgres.mock')
 
+    bucket_keys = list(bucket.s3keys.copy().keys())
+    bucket_keys.sort()
+
+    manifest = bucket_keys.pop(0)
+
+    assert manifest.endswith('.manifest')
     
+    key_list = [x.split("_")[3] for x in bucket_keys]
+
+    comparison_list = ["".join([str(y),'.csv']) for y in range(0,10)]  
+
+    assert key_list == comparison_list
 
     from pprint import pprint;import pytest;pytest.set_trace()
     foo = 1
+
+

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -78,7 +78,7 @@ def test_copy_table_to_redshift(postgres, tmpdir):
 
     # Set up mocking behavior
     cur = postgres.connection.cursor()
-    cur.return_rows = [("test_table",)]
+    cur.return_rows = [(1,)]
 
     postgres.copy_table_to_redshift("test_table", "test_table",
                                     'com.simple.postgres.mock',

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -75,6 +75,11 @@ def test_write_chunk_to_s3(postgres, tmpdir):
 
 @pytest.mark.postgrestest
 def test_copy_table_to_redshift(postgres, tmpdir):
+
+    # Set up mocking behavior
+    cur = postgres.connection.cursor()
+    cur.return_rows = [("test_table",)]
+
     postgres.copy_table_to_redshift("test_table", 'com.simple.postgres.mock',
                                     "/tmp/backfill/", 10)
 

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -86,7 +86,19 @@ def test_copy_table_to_csv(postgres, tmpdir):
 def test_csv_chunk_generator(postgres, tmpdir):
     csv_path = os.path.join(str(tmpdir), "test_table.csv")
     row_count = postgres.copy_table_to_csv("test_table", csv_path)
-    csv_gen = postgres.get_csv_chunk_generator(csv_path, row_count, 10)
-    chunks = [x for x in csv_gen]
 
-    assert len(chunks) == 10
+    def test_row_ids(chunks):
+        all_row_ids = []
+        for chunk in chunks:
+            rows = chunk.split('\n')
+            all_row_ids.extend([int(row.split(',')[0]) for row in rows[:-1]])
+
+        assert all_row_ids == [x for x in range(0, 300, 1)]
+
+    for chunk_size in range(1, 30, 1):
+
+        csv_gen = postgres.get_csv_chunk_generator(csv_path, row_count, chunk_size)
+        chunks = [x for x in csv_gen]
+
+        assert len(chunks) == chunk_size
+        test_row_ids(chunks)

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -5,6 +5,9 @@ Tests for PostgresMixin
 
 Test Runner: PyTest
 """
+import os
+import random
+import uuid
 
 import psycopg2
 import pytest
@@ -23,12 +26,31 @@ def postgres(request):
                                       user="shiftmanager")
     cur = conn.cursor()
 
+    # Just in case of an unclean exit
+    drop_if_exists_query = "DROP TABLE IF EXISTS test_table;"
+
+    cur.execute(drop_if_exists_query)
+
+    # Temp table for test runs; schema is arbitrary.
     create_query = """CREATE TABLE test_table (
                           uuid char(36),
                           number integer,
                           name varchar(255));"""
 
     cur.execute(create_query)
+
+    # Fill table with a few hundred rows of random data
+    names = {"jill", "jane", "joe", "jim", "carol"}
+    insert_statement = ["INSERT INTO test_table VALUES"]
+    for i in range(0, 300, 1):
+        name = random.sample(names, 1)[0]
+        row_to_insert = " ('{uuid}', {number}, '{name}'),".format(
+            uuid=uuid.uuid4(), number=random.randint(0, 100), name=name)
+        insert_statement.append(row_to_insert)
+
+    joined_insert = "".join(insert_statement)
+    complete_insert = "{};".format(joined_insert[:-1])
+    cur.execute(complete_insert)
     conn.commit()
 
     def teardown_pg():
@@ -39,7 +61,21 @@ def postgres(request):
         conn.close()
 
     request.addfinalizer(teardown_pg)
+    return pg
 
 @pytest.mark.postgrestest
 def test_get_connection(postgres):
-    assert True is True
+    cur = postgres.pg_connection.cursor()
+    cur.execute("SELECT COUNT(*) FROM test_table;")
+    count = [row for row in cur][0][0]
+    assert 300 == 300
+
+@pytest.mark.postgrestest
+def test_copy_table_to_csv(postgres, tmpdir):
+    csv_path = os.path.join(str(tmpdir), "test_table.csv")
+    postgres.copy_table_to_csv("test_table", csv_path)
+    assert os.path.isfile(csv_path) == True
+
+    with open(csv_path, "r") as f:
+        rows = [row for row in f]
+        assert len(rows) == 300

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -64,7 +64,7 @@ def test_write_chunk_to_s3(postgres, tmpdir):
     chunks = [x for x in csv_gen]
 
     bucket = postgres.get_bucket('com.simple.postgres.mock')
-    postgres.write_csv_chunk_to_S3(chunks[0], bucket, 'tmp_chunk_1.csv')
+    postgres.write_csv_chunk_to_s3(chunks[0], bucket, 'tmp_chunk_1.csv')
 
     assert 'tmp_chunk_1.csv' == [x for x in bucket.s3keys.keys()][0]
 
@@ -97,3 +97,16 @@ def test_copy_table_to_redshift(postgres, tmpdir):
     comparison_list = ["".join([str(y), '.csv']) for y in range(0, 10)]
 
     assert key_list == comparison_list
+
+    copy_statement = cur.statements[-1]
+
+    from pprint import pprint;import pytest;pytest.set_trace()
+
+    split_statement = [x.strip() for x in copy_statement.split("\n")]
+
+    assert split_statement[0] == "copy test_table"
+    assert (split_statement[1].startswith("from 's3://com.simple.mock/tmp/backfill/") and
+            split_statement[1].endswith(".manifest'"))
+    assert split_statement[2] == "credentials 'aws_access_key_id=None;aws_secret_access_key=None'"
+    assert split_statement[3] == "manifest"
+    assert split_statement[4] == "csv;"

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -48,7 +48,7 @@ def test_csv_chunk_generator(postgres, tmpdir):
 
     for num_chunks in range(1, 30, 1):
 
-        csv_gen = postgres.get_csv_chunk_generator(csv_path, row_count, num_chunks)
+        csv_gen = postgres.get_csv_chunk_generator(csv_path, row_count, num_chunks) 
         chunks = [x for x in csv_gen]
 
         assert len(chunks) == num_chunks
@@ -68,4 +68,18 @@ def test_write_chunk_to_s3(postgres, tmpdir):
     assert 'tmp_chunk_1.csv' == [x for x in bucket.s3keys.keys()][0]
 
     val = [x for x in bucket.s3keys.values()][0]
-    val.set_contents_from_string.assert_called_once_with(chunks[0], encrypt_key=True)
+    val.set_contents_from_string.assert_called_once_with(chunks[0],
+        encrypt_key=True)
+
+
+@pytest.mark.postgrestest
+def test_copy_table_to_redshift(postgres, tmpdir):
+    postgres.copy_table_to_redshift("test_table", 'com.simple.postgres.mock',
+                                    "/tmp/backfill/", 10)
+
+    bucket = postgres.get_bucket('com.simple.postgres.mock')
+
+    
+
+    from pprint import pprint;import pytest;pytest.set_trace()
+    foo = 1

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -7,10 +7,7 @@ Test Runner: PyTest
 """
 import os
 
-import psycopg2
 import pytest
-
-from shiftmanager import util
 
 
 @pytest.mark.postgrestest
@@ -18,7 +15,7 @@ def test_get_connection(postgres):
     cur = postgres.pg_connection.cursor()
     cur.execute("SELECT COUNT(*) FROM test_table;")
     count = [row for row in cur][0][0]
-    assert 300 == 300
+    assert 300 == count
 
 
 @pytest.mark.postgrestest
@@ -104,8 +101,13 @@ def test_copy_table_to_redshift(postgres, tmpdir):
     split_statement = [x.strip() for x in copy_statement.split("\n")]
 
     assert split_statement[0] == "copy test_table"
-    assert (split_statement[1].startswith("from 's3://com.simple.mock/tmp/backfill/") and
-            split_statement[1].endswith(".manifest'"))
-    assert split_statement[2] == "credentials 'aws_access_key_id=None;aws_secret_access_key=None'"
+
+    s3_start = "from 's3://com.simple.mock/tmp/backfill/"
+    s3_end = ".manifest'"
+    assert (split_statement[1].startswith(s3_start) and
+            split_statement[1].endswith(s3_end))
+
+    creds = "credentials 'aws_access_key_id=None;aws_secret_access_key=None'"
+    assert split_statement[2] == creds
     assert split_statement[3] == "manifest"
     assert split_statement[4] == "csv;"

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -25,7 +25,7 @@ def test_get_connection(postgres):
 def test_copy_table_to_csv(postgres, tmpdir):
     csv_path = os.path.join(str(tmpdir), "test_table.csv")
     row_count = postgres.copy_table_to_csv("test_table", csv_path)
-    assert os.path.isfile(csv_path) == True
+    assert os.path.isfile(csv_path) is True
     assert row_count == 300
 
     with open(csv_path, "r") as f:
@@ -48,7 +48,8 @@ def test_csv_chunk_generator(postgres, tmpdir):
 
     for num_chunks in range(1, 30, 1):
 
-        csv_gen = postgres.get_csv_chunk_generator(csv_path, row_count, num_chunks) 
+        csv_gen = postgres.get_csv_chunk_generator(csv_path,
+                                                   row_count, num_chunks)
         chunks = [x for x in csv_gen]
 
         assert len(chunks) == num_chunks
@@ -69,12 +70,11 @@ def test_write_chunk_to_s3(postgres, tmpdir):
 
     val = [x for x in bucket.s3keys.values()][0]
     val.set_contents_from_string.assert_called_once_with(chunks[0],
-        encrypt_key=True)
+                                                         encrypt_key=True)
 
 
 @pytest.mark.postgrestest
 def test_copy_table_to_redshift(postgres, tmpdir):
-    from pprint import pprint;import pytest;pytest.set_trace()
     postgres.copy_table_to_redshift("test_table", 'com.simple.postgres.mock',
                                     "/tmp/backfill/", 10)
 
@@ -86,14 +86,9 @@ def test_copy_table_to_redshift(postgres, tmpdir):
     manifest = bucket_keys.pop(0)
 
     assert manifest.endswith('.manifest')
-    
+
     key_list = [x.split("_")[3] for x in bucket_keys]
 
-    comparison_list = ["".join([str(y),'.csv']) for y in range(0,10)]  
+    comparison_list = ["".join([str(y), '.csv']) for y in range(0, 10)]
 
     assert key_list == comparison_list
-
-    from pprint import pprint;import pytest;pytest.set_trace()
-    foo = 1
-
-

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -6,63 +6,12 @@ Tests for PostgresMixin
 Test Runner: PyTest
 """
 import os
-import random
-import uuid
 
 import psycopg2
 import pytest
 
-import shiftmanager.mixins.postgres as sp
 from shiftmanager import util
 
-@pytest.fixture(scope="session")
-def postgres(request):
-    """
-    Setup Postgres table with a few random columns of data for testing.
-    Tear down table at end of text fixture context.
-    """
-
-    pg = sp.PostgresMixin()
-    conn = pg.get_postgres_connection(database="shiftmanager",
-                                      user="shiftmanager")
-    cur = conn.cursor()
-
-    # Just in case of an unclean exit
-    drop_if_exists_query = "DROP TABLE IF EXISTS test_table;"
-
-    cur.execute(drop_if_exists_query)
-
-    # Temp table for test runs; schema is arbitrary.
-    create_query = """CREATE TABLE test_table (
-                          row_count integer,
-                          uuid char(36),
-                          name varchar(255));"""
-
-    cur.execute(create_query)
-
-    # Fill table with a few hundred rows of random data
-    names = {"jill", "jane", "joe", "jim", "carol"}
-    insert_statement = ["INSERT INTO test_table VALUES"]
-    for i in range(0, 300, 1):
-        name = random.sample(names, 1)[0]
-        row_to_insert = " ({row_count}, '{uuid}', '{name}'),".format(
-            row_count=i, uuid=uuid.uuid4(), name=name)
-        insert_statement.append(row_to_insert)
-
-    joined_insert = "".join(insert_statement)
-    complete_insert = "{};".format(joined_insert[:-1])
-    cur.execute(complete_insert)
-    conn.commit()
-
-    def teardown_pg():
-        drop_query = "DROP TABLE test_table;"
-        cur.execute(drop_query)
-        conn.commit()
-        cur.close()
-        conn.close()
-
-    request.addfinalizer(teardown_pg)
-    return pg
 
 @pytest.mark.postgrestest
 def test_get_connection(postgres):
@@ -70,6 +19,7 @@ def test_get_connection(postgres):
     cur.execute("SELECT COUNT(*) FROM test_table;")
     count = [row for row in cur][0][0]
     assert 300 == 300
+
 
 @pytest.mark.postgrestest
 def test_copy_table_to_csv(postgres, tmpdir):
@@ -81,6 +31,7 @@ def test_copy_table_to_csv(postgres, tmpdir):
     with open(csv_path, "r") as f:
         rows = [row for row in f]
         assert len(rows) == 300
+
 
 @pytest.mark.postgrestest
 def test_csv_chunk_generator(postgres, tmpdir):
@@ -95,10 +46,26 @@ def test_csv_chunk_generator(postgres, tmpdir):
 
         assert all_row_ids == [x for x in range(0, 300, 1)]
 
-    for chunk_size in range(1, 30, 1):
+    for num_chunks in range(1, 30, 1):
 
-        csv_gen = postgres.get_csv_chunk_generator(csv_path, row_count, chunk_size)
+        csv_gen = postgres.get_csv_chunk_generator(csv_path, row_count, num_chunks)
         chunks = [x for x in csv_gen]
 
-        assert len(chunks) == chunk_size
+        assert len(chunks) == num_chunks
         test_row_ids(chunks)
+
+
+@pytest.mark.postgrestest
+def test_write_chunk_to_s3(postgres, tmpdir):
+    csv_path = os.path.join(str(tmpdir), "test_table.csv")
+    row_count = postgres.copy_table_to_csv("test_table", csv_path)
+    csv_gen = postgres.get_csv_chunk_generator(csv_path, row_count, 30)
+    chunks = [x for x in csv_gen]
+
+    bucket = postgres.get_bucket('com.simple.postgres.mock')
+    postgres.write_csv_chunk_to_S3(chunks[0], bucket, 'tmp_chunk_1.csv')
+
+    assert 'tmp_chunk_1.csv' == [x for x in bucket.s3keys.keys()][0]
+
+    val = [x for x in bucket.s3keys.values()][0]
+    val.set_contents_from_string.assert_called_once_with(chunks[0], encrypt_key=True)

--- a/shiftmanager/tests/test_s3.py
+++ b/shiftmanager/tests/test_s3.py
@@ -131,7 +131,7 @@ def test_copy_to_json(shift, json_data, tmpdir):
                              slices=5)
 
     # Get our mock bucket
-    bukkit = shift.s3_conn.get_bucket("foo")
+    bukkit = shift.s3_conn.get_bucket("com.simple.mock")
     # 5 slices, one manifest, one jsonpaths
     check_key_calls(bukkit.s3keys, 5)
     mfest, jpaths = get_manifest_and_jsonpaths_keys(bukkit.s3keys)
@@ -162,7 +162,7 @@ def test_copy_to_json(shift, json_data, tmpdir):
                              slices=4,
                              clean_up_s3=False)
 
-    bukkit = shift.s3_conn.get_bucket("foo")
+    bukkit = shift.s3_conn.get_bucket("com.simple.mock")
     # 4 slices
     check_key_calls(bukkit.s3keys, 4)
 
@@ -180,6 +180,6 @@ def test_copy_to_json(shift, json_data, tmpdir):
                              slices=10,
                              local_path=dpath,
                              clean_up_local=False)
-    bukkit = shift.s3_conn.get_bucket("foo")
+    bukkit = shift.s3_conn.get_bucket("com.simple.mock")
     check_key_calls(bukkit.s3keys, 10)
     assert len(os.listdir(dpath)) == 10

--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,5 @@ addopts =
     --doctest-modules
     --ignore=setup.py
     --ignore=docs/conf.py
+    -m "not postgrestest"
 doctest_optionflags = NORMALIZE_WHITESPACE


### PR DESCRIPTION
Added functions to:

- write table from Postgres to a CSV in a temp directory
- divide that CSV into N groups, where N is the number of slices in Redshift
- write each group to S3
- generate a manifest for all groups
- copy groups to Redshift
- TEST!