### PR TITLE
BUG: Postgres chunker misses rows from small tables

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.3.0'
+version = '0.3.1'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis']
 authors_string = ', '.join(authors)

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -123,6 +123,11 @@ class PostgresMixin(S3Mixin):
         ------
         str
         """
+        # Yield only a single chunk if the number of rows is small.
+        if row_count <= chunks:
+            with open(csv_file_path, "r") as f:
+                yield f.read()
+            raise StopIteration
 
         # Get chunk boundaries
         left_closed_boundary = util.linspace(0, row_count, chunks)

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -44,7 +44,7 @@ def test_pg_copy_table_to_csv(postgres, tmpdir):
 
 
 @pytest.mark.postgrestest
-@pytest.mark.parametrize("limit", [1, 5, 10, 29, 30, 100, 300])
+@pytest.mark.parametrize("limit", [1, 5, 13, 29, 30, 31, 97, 300])
 def test_csv_chunk_generator(postgres, tmpdir, limit):
     csv_path = os.path.join(str(tmpdir), "test_table.csv")
     select_statement = "select * from test_table LIMIT %s" % limit


### PR DESCRIPTION
The chunker logic for PostgresMixin fails when the total number of rows in the table is less than the desired number of chunks. 

I still don't fully understand how the existing logic fails, but this PR adds a failing test for the small table case and corrects it by handling small tables as a special case (only emit a single chunk when the total number of rows is less than the desired number of chunks). There may be better solutions for this.