### PR TITLE
Allow redshift->S3 authentication by IAM role

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,11 +13,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 
 # Hide nonlocal image warnings.
-_standard_warn_node = sphinx.environment.BuildEnvironment.warn_node
-def _warn_node(self, msg, node):
-    if not msg.startswith('nonlocal image URI found:'):
-        _standard_warn_node(self, msg, node)
-sphinx.environment.BuildEnvironment.warn_node = _warn_node
+suppress_warnings = ['image.nonlocal_uri']
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,11 +9,12 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.3.1'
+version = '0.4.0'
 description = 'Management tools for Amazon Redshift'
-authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis']
+authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis', 'Allison Keene']
 authors_string = ', '.join(authors)
-emails = ['klukas@simple.com', 'rob@simple.com', 'meli@simple.com']
+emails = ['klukas@simple.com', 'rob@simple.com', 'meli@simple.com',
+          'allison@simple.com']
 license = 'BSD'
 copyright = '2015 ' + authors_string
 url = 'https://shiftmanager.readthedocs.org'

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -151,6 +151,21 @@ class PostgresMixin(S3Mixin):
                     yield "".join(chunk_lines)
                     chunk_lines = []
 
+    @property
+    def aws_credentials(self):
+        if self.aws_account_id and self.aws_role_name:
+            template = ('aws_iam_role=arn:aws:iam::'
+                        '{aws_account_id}:role/{role_name}')
+            return template.format(aws_account_id=self.aws_account_id,
+                                   role_name=self.aws_role_name)
+        else:
+            key_id = 'aws_access_key_id={};'.format(self.aws_access_key_id)
+            secret_key_id = 'aws_secret_access_key={}'.format(
+                self.aws_secret_access_key)
+            template = '{key_id}{secret_key_id}'
+            return template.format(key_id=key_id,
+                                   secret_key_id=secret_key_id)
+
     def _create_copy_statement(self, table_name, manifest_key_path):
         """Create Redshift copy statement for given table_name and
         the provided manifest_key_path.
@@ -167,18 +182,13 @@ class PostgresMixin(S3Mixin):
         str
         """
 
-        key_id = 'aws_access_key_id={};'.format(self.aws_access_key_id)
-        secret_key_id = 'aws_secret_access_key={}'.format(
-            self.aws_secret_access_key)
-
         return """copy {table_name}
                   from '{manifest_key_path}'
-                  credentials '{key_id}{secret_key_id}'
+                  credentials '{aws_credentials}'
                   manifest
                   csv;""".format(table_name=table_name,
                                  manifest_key_path=manifest_key_path,
-                                 key_id=key_id,
-                                 secret_key_id=secret_key_id)
+                                 aws_credentials=self.aws_credentials)
 
     def copy_table_to_redshift(self, redshift_table_name,
                                bucket_name, key_prefix, slices,

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -163,6 +163,9 @@ class PostgresMixin(S3Mixin):
             secret_key_id = 'aws_secret_access_key={}'.format(
                 self.aws_secret_access_key)
             template = '{key_id}{secret_key_id}'
+            if self.security_token:
+                template += ";token={security_token}".format(
+                    security_token=self.security_token)
             return template.format(key_id=key_id,
                                    secret_key_id=secret_key_id)
 

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -38,6 +38,8 @@ class S3Mixin(object):
 
     def __init__(self, *args, **kwargs):
         self.s3_conn = None
+        self.aws_account_id = None
+        self.aws_role_name = None
 
     def set_aws_credentials(self, aws_access_key_id, aws_secret_access_key,
                             security_token=None):
@@ -55,6 +57,20 @@ class S3Mixin(object):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.security_token = security_token
+
+    def set_aws_role(self, aws_account_id, aws_role_name):
+        """
+        Set AWS IAM role. This rote will be assumed by the Redshift cluster
+        when reading from S3 during COPY statements. If not set, the access key
+        and secret from set_aws_credentials will be used.
+
+        Parameters
+        ----------
+        aws_account_id : str
+        aws_role_name : str
+        """
+        self.aws_account_id = aws_account_id
+        self.aws_role_name = aws_role_name
 
     def get_s3_connection(self, ordinary_calling_fmt=False):
         """

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -145,3 +145,20 @@ def test_aws_role_copy(postgres, tmpdir):
 
     creds = "credentials 'aws_iam_role=arn:aws:iam::000000:role/TestRole'"
     assert split_statement[2] == creds
+
+
+@pytest.mark.postgrestest
+def test_aws_security_token(postgres, tmpdir):
+    cur = postgres.connection.cursor()
+    cur.return_rows = [(1,)]
+
+    postgres.set_aws_credentials('access_key', 'secret_key', 'sec_token')
+    postgres.copy_table_to_redshift('test_table', 'com.simple.postgres.mock',
+                                    '/tmp/backfill/', 10, 'test_table')
+
+    copy_statement = cur.statements[-1]
+    split_statement = [x.strip() for x in copy_statement.split("\n")]
+
+    creds = ("credentials 'aws_access_key_id=access_key;"
+             "aws_secret_access_key=secret_key;token=sec_token'")
+    assert split_statement[2] == creds

--- a/shiftmanager/tests/test_postgres.py
+++ b/shiftmanager/tests/test_postgres.py
@@ -129,3 +129,19 @@ def test_copy_table_to_redshift(postgres, tmpdir):
     assert split_statement[2] == creds
     assert split_statement[3] == "manifest"
     assert split_statement[4] == "csv;"
+
+
+@pytest.mark.postgrestest
+def test_aws_role_copy(postgres, tmpdir):
+    cur = postgres.connection.cursor()
+    cur.return_rows = [(1,)]
+
+    postgres.set_aws_role('000000', 'TestRole')
+    postgres.copy_table_to_redshift('test_table', 'com.simple.postgres.mock',
+                                    '/tmp/backfill/', 10, 'test_table')
+
+    copy_statement = cur.statements[-1]
+    split_statement = [x.strip() for x in copy_statement.split("\n")]
+
+    creds = "credentials 'aws_iam_role=arn:aws:iam::000000:role/TestRole'"
+    assert split_statement[2] == creds

--- a/shiftmanager/tests/test_s3.py
+++ b/shiftmanager/tests/test_s3.py
@@ -43,6 +43,12 @@ def test_connection_with_security_token(shift):
     assert shift.security_token == 'my_token'
 
 
+def test_connection_with_role(shift):
+    shift.set_aws_role('my_account_id', 'my_role_name')
+    assert shift.aws_account_id == 'my_account_id'
+    assert shift.aws_role_name == 'my_role_name'
+
+
 def test_jsonpaths(shift):
 
     test_dict_1 = {"one": 1, "two": {"three": 3}}


### PR DESCRIPTION
Add configuration option to use an associated IAM role when performing the COPY statement in Redshift. This removes the need for user access/secret tokens.