### PR TITLE
More postgres options

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.4.0'
+version = '0.5.0'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis', 'Allison Keene']
 authors_string = ', '.join(authors)

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -142,7 +142,8 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
         boundary_index = 0
         boundary = right_closed_boundary[boundary_index]
         one_mebibyte = 1048576
-        with codecs.open(csv_file_path, mode="r", encoding='utf-8', buffering=one_mebibyte) as f:
+        with codecs.open(csv_file_path, mode="r", encoding='utf-8',
+                         buffering=one_mebibyte) as f:
             for line_number, row in enumerate(f):
                 chunk_lines.append(row)
                 if line_number == boundary:

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -27,12 +27,9 @@ class PostgresMixin(S3Mixin):
 
         Instantiation is delayed until the object is first used.
         """
-        print("Connecting to %s..." % self.pg_host)
-        return psycopg2.connect(user=self.pg_user,
-                                host=self.pg_host,
-                                port=self.pg_port,
-                                database=self.pg_database,
-                                password=self.pg_password)
+
+        print("Connecting to %s..." % self.pg_args['host'])
+        return psycopg2.connect(**self.pg_args)
 
     def pg_execute_and_commit_single_statement(self, statement):
         """Execute single Postgres statement"""
@@ -40,17 +37,20 @@ class PostgresMixin(S3Mixin):
             with conn.cursor() as cur:
                 cur.execute(statement)
 
-    def create_pg_connection(self, database=None, user=None, password=None,
-                             host='localhost', port=5432):
+    def create_pg_connection(self, **kwargs):
         """
         Create a `psycopg2.connect` connection to Redshift.
+
+        See https://www.postgresql.org/docs/current/static/\
+libpq-connect.html#LIBPQ-PARAMKEYWORDS
+        for supported parameters.
         """
 
-        self.pg_user = user
-        self.pg_host = host
-        self.pg_port = port
-        self.pg_database = database
-        self.pg_password = password
+        # Use 'localhost' as default host rather than unix socket
+        if 'host' not in kwargs:
+            kwargs['host'] = 'localhost'
+
+        self.pg_args = kwargs
         return self.pg_connection
 
     def pg_copy_table_to_csv(self, csv_file_path, pg_table_name=None,

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -7,6 +7,7 @@ Mixin classes for working with Postgres database exports
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import codecs
 from datetime import datetime
 import json
 import tempfile
@@ -125,7 +126,7 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
         """
         # Yield only a single chunk if the number of rows is small.
         if row_count <= chunks:
-            with open(csv_file_path, "r") as f:
+            with codecs.open(csv_file_path, mode="r", encoding='utf-8') as f:
                 yield f.read()
             raise StopIteration
 
@@ -141,14 +142,14 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
         boundary_index = 0
         boundary = right_closed_boundary[boundary_index]
         one_mebibyte = 1048576
-        with open(csv_file_path, "r", one_mebibyte) as f:
+        with codecs.open(csv_file_path, mode="r", encoding='utf-8', buffering=one_mebibyte) as f:
             for line_number, row in enumerate(f):
                 chunk_lines.append(row)
                 if line_number == boundary:
                     if boundary_index != final_boundary_index:
                         boundary_index += 1
                         boundary = right_closed_boundary[boundary_index]
-                    yield "".join(chunk_lines)
+                    yield u"".join(chunk_lines)
                     chunk_lines = []
 
     @property

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -195,7 +195,8 @@ class PostgresMixin(S3Mixin):
 
     def copy_table_to_redshift(self, redshift_table_name,
                                bucket_name, key_prefix, slices,
-                               pg_table_name=None, pg_select_statement=None):
+                               pg_table_name=None, pg_select_statement=None,
+                               temp_file_dir=None):
         """
         Write the contents of a Postgres table to Redshift.
         Write the table to the given bucket under the given
@@ -217,6 +218,8 @@ class PostgresMixin(S3Mixin):
             does not want to specify subset
         pg_select_statement: str
             Optional select statement if user wants to specify subset of table
+        temp_file_dir: str
+            Optional Specify location of temporary files
         """
         if not self.table_exists(redshift_table_name):
             raise ValueError("This table_name does not exist in Redshift!")
@@ -230,7 +233,7 @@ class PostgresMixin(S3Mixin):
         else:
             final_key_prefix = key_prefix
 
-        with tempfile.NamedTemporaryFile() as ntf:
+        with tempfile.NamedTemporaryFile(dir=temp_file_dir) as ntf:
             csv_temp_path = ntf.name
             row_count = self.pg_copy_table_to_csv(
                 csv_temp_path, pg_table_name=pg_table_name,


### PR DESCRIPTION
Add more options to postgres to redshift copies:

* Select location of temp files
* Optionally skip S3 cleanup for debugging
* Support more psycopg2 connection options in pg_connection

This is formalization of changes I made in order to work through issues doing a backfill from postgres->redshift.