### PR TITLE
Add FORCE QUOTE to Postgres COPY command

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.5.0'
+version = '0.5.1'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis', 'Allison Keene']
 authors_string = ', '.join(authors)

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -78,7 +78,12 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
         -------
         row_count: int
         """
-        copy = "COPY {pg_table_or_select} TO '{csv_fp}' DELIMITER ',' CSV;"
+        copy = ' '.join([
+            "COPY {pg_table_or_select}",
+            "TO '{csv_fp}'",
+            "DELIMITER ','",
+            "FORCE QUOTE *",
+            "CSV;"])
 
         if pg_select_statement is None and pg_table_name is not None:
 


### PR DESCRIPTION
I had the load into Redshift bail due to values that contained a newline. FORCE QUOTE correctly encapsulated values including a newline.

cc @wrobstory @xstevens @alialliallie 