### PR TITLE
Dedupe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,11 @@ To retain only the most recently ingested row for each unique id, call::
             deduplicate_partition_by='message_id',
             deduplicate_order_by='when_recorded DESC')
 
+When using ``deduplicate_partition_by``, only the first row returned for
+any given value of the partitioning columns is retained. It's strongly
+suggested that you supply a value for ``deduplicate_order_by`` to determine
+how that initial row is chosen.
+
 `deep_copy` can also be used to migrate an existing table to a new structure,
 providing a convenient way to alter distkeys, sortkeys, and column encodings.
 Additional keyword arguments will be passed to the `reflected_table` method,

--- a/README.rst
+++ b/README.rst
@@ -132,15 +132,23 @@ behind the scenes to recreate the relevant DDL::
 
 To remove duplicate records while recreating the table,
 pass in the ``distinct=True`` keyword argument.
+If you have rows you consider duplicates despite some difference in their
+values, you can use the ``deduplicate_partition_by`` option.
+For example, say that rows include a ``message_id`` column that should be
+unique, but also a ``when_recorded`` column set when the record is ingested.
+To retain only the most recently ingested row for each unique id, call::
+
+  deep_copy('my_table',
+            deduplicate_partition_by='message_id',
+            deduplicate_order_by='when_recorded DESC')
 
 `deep_copy` can also be used to migrate an existing table to a new structure,
 providing a convenient way to alter distkeys, sortkeys, and column encodings.
-Use the `reflected_table` method to generate a modified
-`sqlalchemy.schema.Table` object, and pass that in rather than a table name::
+Additional keyword arguments will be passed to the `reflected_table` method,
+altering the reflected `sqlalchemy.schema.Table`::
 
   >>> kwargs = dict(redshift_distkey='email_address', redshift_sortkey=('email_address', 'id'))
-  >>> table = redshift.reflected_table('my_table', schema='my_schema', **kwargs)
-  >>> batch = redshift.deep_copy(table)
+  >>> batch = redshift.deep_copy('my_table', schema='my_schema', **kwarg)
   >>> print(batch)
   LOCK TABLE my_schema.my_table;
   ALTER TABLE my_schema.my_table RENAME TO my_table$outgoing;
@@ -148,14 +156,13 @@ Use the `reflected_table` method to generate a modified
   CREATE TABLE my_schema.my_table (
           id CHAR(36) ENCODE lzo,
           email_address VARCHAR(256) ENCODE raw
-  ) DISTSTYLE KEY DISTKEY (email_address) SORTKEY (email_address, id)
+  ) DISTSTYLE KEY DISTKEY (email_address) SORTKEY (email_address, id);
 
-  ;
   ALTER TABLE my_schema.my_table OWNER TO chad;
-  GRANT ALL ON my_schema.my_table TO clarissa
+  GRANT ALL ON my_schema.my_table TO clarissa;
 
   INSERT INTO my_schema.my_table SELECT * from my_schema.my_table$outgoing;
-  DROP TABLE my_schema.my_table$outgoing
+  DROP TABLE my_schema.my_table$outgoing;
 
 If you pass ``analyze_compress=True`` to `deep_copy`, compression encodings
 will be updated in the resultant table based on results of running

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ To retain only the most recently ingested row for each unique id, call::
 
   deep_copy('my_table',
             deduplicate_partition_by='message_id',
-            deduplicate_order_by='when_recorded DESC')
+            deduplicate_order_by='when_recorded DESC NULLS LAST')
 
 When using ``deduplicate_partition_by``, only the first row returned for
 any given value of the partitioning columns is retained. It's strongly

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -298,7 +298,8 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
-    'sqlalchemy': ('https://sqlalchemy.readthedocs.org/en/latest/', None),
-    'psycopg2': ('http://initd.org/psycopg/docs/', None)
+    'python': ('https://docs.python.org/3/', None),
+    'sqlalchemy': ('https://sqlalchemy.readthedocs.io/en/latest/', None),
+    'sqlalchemyredshift': ('https://sqlalchemy-redshift.readthedocs.io/en/latest/', None),
+    'psycopg2': ('http://initd.org/psycopg/docs/', None),
 }

--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,12 +9,12 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.5.1'
+version = '0.6.0'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis', 'Allison Keene']
 authors_string = ', '.join(authors)
 emails = ['klukas@simple.com', 'rob@simple.com', 'meli@simple.com',
           'allison@simple.com']
 license = 'BSD'
-copyright = '2015 ' + authors_string
+copyright = '2016 ' + authors_string
 url = 'https://shiftmanager.readthedocs.org'

--- a/shiftmanager/mixins/reflection.py
+++ b/shiftmanager/mixins/reflection.py
@@ -238,7 +238,9 @@ class ReflectionMixin(object):
         deduplicate_partition_by: `str` or `None`
             A string giving a list of columns like 'col1, col2' to be passed
             to 'ROW_NUMBER() OVER (PARTITION BY {columns})' so that only the
-            first row for a given set of values will be retained
+            first row for a given set of values will be retained;
+            it's strongly suggested that you also set
+            *deduplicate_order_by* so that results are deterministic
         deduplicate_order_by: `str` or `None`
             A string like 'col3 DESC, col4 ASC' to be passed to the
             'PARTITION BY' clause to determine ordering for deduplication;

--- a/shiftmanager/mixins/reflection.py
+++ b/shiftmanager/mixins/reflection.py
@@ -242,9 +242,9 @@ class ReflectionMixin(object):
             it's strongly suggested that you also set
             *deduplicate_order_by* so that results are deterministic
         deduplicate_order_by: `str` or `None`
-            A string like 'col3 DESC, col4 ASC' to be passed to the
-            'PARTITION BY' clause to determine ordering for deduplication;
-            the first row in sort order will be the one retained;
+            A string like 'col3 DESC NULLS LAST, col4 ASC NULLS LAST' to be
+            passed to the 'PARTITION BY' clause for deduplication, with
+            the first row in sort order being the one retained;
             will be ignored if *deduplicate_partition_by* is not also set
         execute : `bool`
             Execute the command in addition to returning it.

--- a/shiftmanager/mixins/reflection.py
+++ b/shiftmanager/mixins/reflection.py
@@ -177,10 +177,10 @@ class ReflectionMixin(object):
         use_cache : `bool`
             Use cached results for the privilege query, if available
         execute : `bool`
-            Execute the command in addition to returning it.
+            Execute the command in addition to returning it
         kwargs :
-            Additional keyword arguments will be passed unchanged to the
-            `get_view_definition` method.
+            Additional keyword arguments will be passed unchanged to
+            :meth:`~sqlalchemy_redshift.dialect.RedshiftDialect.get_view_definition`
         """
         view = self._pass_or_reflect(view, schema)
         definition = self.engine.dialect.get_view_definition(

--- a/shiftmanager/tests/test_reflection.py
+++ b/shiftmanager/tests/test_reflection.py
@@ -16,6 +16,14 @@ def table():
                     sa.schema.Column("col1", sa.INTEGER))
 
 
+@pytest.fixture
+def complex_table():
+    return sa.Table("my_complex_table", sa.MetaData(),
+                    sa.schema.Column("col1", sa.INTEGER),
+                    sa.schema.Column("col2", sa.INTEGER),
+                    sa.schema.Column("col3", sa.INTEGER))
+
+
 def cleaned(statement):
     text = str(statement)
     stripped_lines = [line.strip() for line in text.split('\n')]
@@ -34,31 +42,65 @@ class SqlTextMatcher(object):
         return cleaned(self.text) == cleaned(text)
 
 
-def test_dedupe(shift, table):
-    statement = shift.deep_copy(table, distinct=True, copy_privileges=False)
+def test_deep_copy_distinct(shift, table):
+    statement = shift.deep_copy(table, distinct=True,
+                                copy_privileges=False, analyze=False)
     expected = """
     LOCK TABLE my_table;
     ALTER TABLE my_table RENAME TO my_table$outgoing;
     CREATE TABLE my_table (
     col1 INTEGER
-    )
-    ;
-    INSERT INTO my_table SELECT DISTINCT * from my_table$outgoing;
-    DROP TABLE my_table$outgoing
+    );
+
+    INSERT INTO my_table SELECT DISTINCT * FROM my_table$outgoing;
+
+    DROP TABLE my_table$outgoing;
     """
     assert(cleaned(statement) == cleaned(expected))
 
 
 def test_cascade(shift, table):
-    statement = shift.deep_copy(table, cascade=True, copy_privileges=False)
+    statement = shift.deep_copy(table, cascade=True,
+                                copy_privileges=False, analyze=False)
     expected = """
     LOCK TABLE my_table;
     ALTER TABLE my_table RENAME TO my_table$outgoing;
     CREATE TABLE my_table (
     col1 INTEGER
-    )
-    ;
-    INSERT INTO my_table SELECT * from my_table$outgoing;
-    DROP TABLE my_table$outgoing CASCADE
+    );
+
+    INSERT INTO my_table SELECT * FROM my_table$outgoing;
+
+    DROP TABLE my_table$outgoing CASCADE;
+    """
+    assert(cleaned(statement) == cleaned(expected))
+
+
+def test_deduplicate(shift, complex_table):
+    statement = shift.deep_copy(complex_table,
+                                deduplicate_partition_by="col1, col2",
+                                deduplicate_order_by="col3 DESC",
+                                copy_privileges=False, analyze=False)
+    expected = """
+    LOCK TABLE my_complex_table;
+    ALTER TABLE my_complex_table RENAME TO my_complex_table$outgoing;
+
+    CREATE TABLE my_complex_table (
+    col1 INTEGER,
+    col2 INTEGER,
+    col3 INTEGER
+    );
+
+    INSERT INTO my_complex_table SELECT
+    "col1",
+    "col2",
+    "col3"
+    FROM (
+    SELECT *, ROW_NUMBER()
+    OVER (PARTITION BY col1, col2 ORDER BY col3 DESC)
+    FROM my_complex_table$outgoing
+    ) WHERE row_number = 1;
+
+    DROP TABLE my_complex_table$outgoing;
     """
     assert(cleaned(statement) == cleaned(expected))


### PR DESCRIPTION
This PR codifies the maintenance task of removing duplicates from a table based not on entire rows being identical, but based on some subset of columns being identical.

This is particularly useful for tables that have some unique id from the source data, but also have some ingestion timestamp that differs if some datum is loaded into the table twice.

This also improves the formatting of the deep_copy output significantly (we used to have semicolons sitting on their own lines and some strange line breaks) and changes some related code in order to be consistent across methods.