### PR TITLE
Faster, json-based methodology for backfill

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,12 +9,13 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.6.0'
+version = '0.6.1'
 description = 'Management tools for Amazon Redshift'
-authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis', 'Allison Keene']
+authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis',
+           'Allison Keene', 'Xavier Stevens']
 authors_string = ', '.join(authors)
 emails = ['klukas@simple.com', 'rob@simple.com', 'meli@simple.com',
-          'allison@simple.com']
+          'allison@simple.com', 'xavier@simple.com']
 license = 'BSD'
 copyright = '2016 ' + authors_string
 url = 'https://shiftmanager.readthedocs.org'

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -192,7 +192,7 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
             "COPY (SELECT row_to_json(x) FROM ({pg_table_or_select}) AS x) "
             "TO PROGRAM $$"
             "split - {tmpdir}/chunk_ --line-bytes={line_bytes} "
-            "--filter='gzip > $FILE.gz'"
+            "--filter='gzip > $FILE.json.gz'"
             """ | sed 's/\\*"/\"/g'"""
             "$$"
         ).format(pg_table_or_select=pg_table_or_select,

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -58,37 +58,6 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
         self.pg_args = kwargs
         return self.pg_connection
 
-    def pg_copy_statement(self,
-                          pg_table_name=None,
-                          pg_select_statement=None):
-        """
-        Create a Postgres COPY statement.
-
-        Parameters
-        ----------
-        pg_table_name: str
-            Optional Postgres table name to be written to if user
-            does not want to specify subset
-        pg_select_statement: str
-            Optional select statement if user wants to specify subset of table
-
-
-        Returns
-        -------
-        A SQL string giving the COPY statement
-        """
-        if pg_select_statement is None and pg_table_name is not None:
-            pg_table_or_select = pg_table_name
-        elif pg_select_statement is not None and pg_table_name is None:
-            pg_table_or_select = '(' + pg_select_statement + ')'
-        else:
-            ValueError("Exactly one of pg_table_name or pg_select_statement "
-                       "must be specified.")
-        copy = ' '.join([
-            "COPY (SELECT row_to_json(x) FROM ({pg_table_or_select}) AS x)",
-            "TO PROGRAM;"]).format(pg_table_or_select=pg_table_or_select)
-        return copy
-
     @property
     def aws_credentials(self):
         if self.aws_account_id and self.aws_role_name:
@@ -121,9 +90,9 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
         str
         """
         return """\
-        copy {table_name}
-        from '{manifest_key_path}'
-        credentials '{aws_credentials}'
+        COPY {table_name}
+        FROM '{manifest_key_path}'
+        CREDENTIALS '{aws_credentials}'
         MANIFEST
         TIMEFORMAT 'auto'
         GZIP

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -292,9 +292,13 @@ class S3UploaderThread(Thread):
         """
         print("Started a thread for uploading files to S3.")
         while (True):
-            files = os.listdir(self.dirpath)
+            files = sorted(os.listdir(self.dirpath))
             if not self.files_still_being_created and not files:
                 break
+            if files and self.files_still_being_created:
+                # The last listed file is the one being written to,
+                # so let's skip it for now.
+                files = files[:-1]
             for basename in files:
                 filepath = os.path.join(self.dirpath, basename)
                 complete_key_path = "".join([self.key_prefix, basename])

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -148,6 +148,40 @@ class S3Mixin(object):
         boto_key = bucket.new_key(s3_key_path)
         boto_key.set_contents_from_string(chunk, encrypt_key=True)
 
+    def write_file_to_s3(self, f, bucket, s3_key_path):
+        """
+        Given a string chunk that represents a piece of a CSV file, write
+        the chunk to an S3 key.
+
+        Parameters
+        ----------
+        chunk: str
+            String blob representing a chunk of a larger CSV
+        bucket: boto.s3.bucket.Bucket
+            The bucket to be written to
+        s3_key_path: str
+            The key path to write the chunk to
+        """
+        boto_key = bucket.new_key(s3_key_path)
+        boto_key.set_contents_from_file(f, encrypt_key=True)
+
+    def write_filename_to_s3(self, filename, bucket, s3_key_path):
+        """
+        Given a string chunk that represents a piece of a CSV file, write
+        the chunk to an S3 key.
+
+        Parameters
+        ----------
+        chunk: str
+            String blob representing a chunk of a larger CSV
+        bucket: boto.s3.bucket.Bucket
+            The bucket to be written to
+        s3_key_path: str
+            The key path to write the chunk to
+        """
+        boto_key = bucket.new_key(s3_key_path)
+        boto_key.set_contents_from_filename(filename, encrypt_key=True)
+
     @check_s3_connection
     def get_bucket(self, bucket_name):
         """


### PR DESCRIPTION
This removes some significant chunks of code and moves to a methodology that puts file splitting and zipping directly into the Postgres COPY command, and uploads files to S3 as they are created.

This code now relies on having the GNU split and gzip tools available on the system, which I see as the biggest downside of this change.