### PR TITLE
Reflection fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ how that initial row is chosen.
 `deep_copy` can also be used to migrate an existing table to a new structure,
 providing a convenient way to alter distkeys, sortkeys, and column encodings.
 Additional keyword arguments will be passed to the `reflected_table` method,
-altering the reflected `sqlalchemy.schema.Table`::
+altering the reflected :class:`~sqlalchemy.schema.Table`::
 
   >>> kwargs = dict(redshift_distkey='email_address', redshift_sortkey=('email_address', 'id'))
   >>> batch = redshift.deep_copy('my_table', schema='my_schema', **kwarg)

--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.6.3'
+version = '0.6.4'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis',
            'Allison Keene', 'Xavier Stevens', 'KF Fellows']

--- a/shiftmanager/mixins/reflection.py
+++ b/shiftmanager/mixins/reflection.py
@@ -47,7 +47,7 @@ class ReflectionMixin(object):
 
     @memoized_property
     def engine(self):
-        """A `sqlalchemy.engine` which wraps `connection`.
+        """A sqlalchemy.engine which wraps `connection`.
         """
         return sqlalchemy.create_engine("redshift+psycopg2://",
                                         poolclass=sqlalchemy.pool.StaticPool,
@@ -55,7 +55,8 @@ class ReflectionMixin(object):
 
     @memoized_property
     def meta(self):
-        """A `sqlalchemy.schema.MetaData` instance used for reflection calls.
+        """A :class:`~sqlalchemy.schema.MetaData` instance used for
+        reflection calls.
         """
         meta = sqlalchemy.MetaData()
         meta.bind = self.engine
@@ -73,11 +74,12 @@ class ReflectionMixin(object):
                                                    **kwargs)
 
     def reflected_table(self, name, *args, **kwargs):
-        """Return a `sqlalchemy.schema.Table` reflected from the database.
+        """
+        Return a :class:`~sqlalchemy.schema.Table` reflected from the database.
 
         This is simply a convenience method which passes arguments to the
-        `sqlalchemy.schema.Table` constructor, so you may override various
-        properties of the existing table.
+        :class:`~sqlalchemy.schema.Table` constructor,
+        so you may override various properties of the existing table.
         In particular, Redshift-specific attributes like
         distkey and sorkey can be set through ``redshift_*`` keyword arguments
         (``redshift_distkey='col1'``,
@@ -117,7 +119,7 @@ class ReflectionMixin(object):
 
         Parameters
 
-        relation : `str` or `sqlalchemy.schema.Table`
+        relation : `str` or :class:`~sqlalchemy.schema.Table`
             The table or view to reflect
         schema : `str`
             The database schema in which to look for *relation*
@@ -136,7 +138,7 @@ class ReflectionMixin(object):
 
         Parameters
         ----------
-        table : `str` or `sqlalchemy.schema.Table`
+        table : `str` or :class:`~sqlalchemy.schema.Table`
             The table to reflect
         schema : `str`
             The database schema in which to look for *table*
@@ -171,7 +173,7 @@ class ReflectionMixin(object):
 
         Parameters
         ----------
-        view : `str` or `sqlalchemy.schema.Table`
+        view : `str` or :class:`~sqlalchemy.schema.Table`
             The view to reflect
         schema : `str`
             The database schema in which to look for *view*
@@ -219,7 +221,7 @@ class ReflectionMixin(object):
 
         Parameters
         ----------
-        table : `str` or `sqlalchemy.schema.Table`
+        table : `str` or :class:`~sqlalchemy.schema.Table`
             The table to reflect
         schema : `str`
             The database schema in which to look for *table*

--- a/shiftmanager/mixins/reflection.py
+++ b/shiftmanager/mixins/reflection.py
@@ -100,6 +100,11 @@ class ReflectionMixin(object):
         analyze_compression = kwargs.pop('analyze_compression', None)
         kw['autoload'] = True
         kw['extend_existing'] = kw.get('extend_existing', True)
+        # Run once with autoload enabled to reflect existing structure.
+        table = sqlalchemy.Table(name, self.meta, *args, **kw)
+        kw['autoload'] = False
+        # And run again without autoload to make sure overrides (like distkey)
+        # are applied.
         table = sqlalchemy.Table(name, self.meta, *args, **kw)
         if analyze_compression:
             for col in table.columns:

--- a/shiftmanager/mixins/reflection.py
+++ b/shiftmanager/mixins/reflection.py
@@ -102,8 +102,9 @@ class ReflectionMixin(object):
         analyze_compression = kwargs.pop('analyze_compression', None)
         kw['autoload'] = True
         kw['extend_existing'] = kw.get('extend_existing', True)
-        # Run once with autoload enabled to reflect existing structure.
-        table = sqlalchemy.Table(name, self.meta, *args, **kw)
+        # Run once with autoload enabled to reflect existing structure
+        # into self.meta
+        sqlalchemy.Table(name, self.meta, *args, **kw)
         kw['autoload'] = False
         # And run again without autoload to make sure overrides (like distkey)
         # are applied.


### PR DESCRIPTION
We found we needed to make repeated calls to this function to get distkey correctly applied. Looks like this goes all the way down to SQLAlchemy. I think the `autoload` option causes the redshift dialect options to get reflected and those will always be put in place in favor of the explicitly passed `redshift_distkey`, etc. params on the first call.

So, we do one call for reflection from Redshift, then a second call to enforce our explicitly passed dialect-specific parameters.