### PR TITLE
Pass through additional psycopg2 kwargs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: python
 python: 3.5
 env:
   matrix:
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=py35
-  - TOX_ENV=docs
-  - TOX_ENV=lint
+    - TOX_ENV=py27
+    - TOX_ENV=py34
+    - TOX_ENV=py35
+    - TOX_ENV=docs
+    - TOX_ENV=lint
 install:
-- pip install tox
+  - pip install tox
 script:
-- tox -e $TOX_ENV
+  - tox -e $TOX_ENV

--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.6.4'
+version = '0.6.5'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis',
            'Allison Keene', 'Xavier Stevens', 'KF Fellows']
@@ -17,5 +17,5 @@ authors_string = ', '.join(authors)
 emails = ['klukas@simple.com', 'allison@simple.com', 'xavier@simple.com',
           'kf@simple.com']
 license = 'BSD'
-copyright = '2016 ' + authors_string
+copyright = '2017 ' + authors_string
 url = 'https://shiftmanager.readthedocs.org'

--- a/shiftmanager/redshift.py
+++ b/shiftmanager/redshift.py
@@ -42,6 +42,8 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin, S3Mixin):
         envvar equivalent: AWS_SECRET_ACCESS_KEY
     security_token : str
         envvar equivalent: AWS_SECURITY_TOKEN or AWS_SESSION_TOKEN
+    kwargs : dict
+        Additional keyword arguments sent to psycopg2.connect
     """
 
     @memoized_property
@@ -55,13 +57,15 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin, S3Mixin):
                                 host=self.host,
                                 port=self.port,
                                 database=self.database,
-                                password=self.password)
+                                password=self.password,
+                                **self.pgkwargs)
 
     def __init__(self, database=None, user=None, password=None, host=None,
                  port=5439,
                  aws_access_key_id=None,
                  aws_secret_access_key=None,
-                 security_token=None):
+                 security_token=None,
+                 **kwargs):
 
         self.set_aws_credentials(aws_access_key_id, aws_secret_access_key,
                                  security_token)
@@ -71,6 +75,7 @@ class Redshift(AdminMixin, ReflectionMixin, PostgresMixin, S3Mixin):
         self.port = port or os.environ.get('PGPORT')
         self.database = database or os.environ.get('PGDATABASE')
         self.password = password or os.environ.get('PGPASSWORD')
+        self.pgkwargs = kwargs
 
         self._all_privileges = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@
 # this directory.
 
 [tox]
-envlist = py27, py33, py34, docs, lint
+envlist = py27, py34, py35, docs, lint
 
 [testenv]
 deps =


### PR DESCRIPTION
Necessary for fine-grained SSL config.