### PR TITLE
handle when there are multiple identity columns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     packages=find_packages(),

--- a/shiftmanager/tests/conftest.py
+++ b/shiftmanager/tests/conftest.py
@@ -106,9 +106,9 @@ def mogrify(self, batch, parameters=None, execute=False):
     return batch
 
 
-def id_col(self, table_name):
+def id_cols(self, table_name):
     if table_name == 'my_identity_table':
-        return 'id_col'
+        return {'id_col'}
 
 
 @pytest.fixture
@@ -121,7 +121,7 @@ def shift(monkeypatch, mock_connection, mock_s3):
                         lambda *args, **kwargs: mock_s3)
     monkeypatch.setattr('shiftmanager.Redshift.mogrify', mogrify)
     monkeypatch.setattr('shiftmanager.Redshift.execute', MagicMock())
-    monkeypatch.setattr('shiftmanager.Redshift._get_identity', id_col)
+    monkeypatch.setattr('shiftmanager.Redshift._get_identity_columns', id_cols)
     shift = rs.Redshift("", "", "", "",
                         aws_access_key_id="access_key",
                         aws_secret_access_key="secret_key",


### PR DESCRIPTION
Tables can have multiple identity columns so they will all need to be excluded when performing a deep copy. 