### PR TITLE
Fix continue-on-error if S3 not cleaned up

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.6.6'
+version = '0.6.7'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis',
            'Allison Keene', 'Xavier Stevens', 'KF Fellows',

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -221,12 +221,14 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
             s3_keys = s3_thread.s3_keys
         except:
             s3_thread.abort()
+            print("Error while pulling data out of PostgreSQL.")
             if cleanup_s3:
-                print("Error while pulling data out of PostgreSQL. "
-                      "Cleaning up S3...")
+                print("Cleaning up S3...")
                 for key in s3_thread.s3_keys:
                     bucket.delete_key(key)
-                raise
+            else:
+                print("Leaving files in place...")
+            raise
 
         print("Uploads all done. Cleaning up temp directory " + tmpdir)
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
If S3 files are left in place, it would continue running if there was an error during the extraction, masking the actual DB error.