### PR TITLE
split out copy to s3 as a separate method

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,14 +9,14 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.6.7'
+version = '0.6.8'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis',
            'Allison Keene', 'Xavier Stevens', 'KF Fellows',
            'Andrew Harris']
 authors_string = ', '.join(authors)
 emails = ['klukas@simple.com', 'allison@simple.com', 'xavier@simple.com',
-          'kf@simple.com', 'andrew@simple.com']
+          'andrew@simple.com']
 license = 'BSD'
 copyright = '2017 ' + authors_string
 url = 'https://shiftmanager.readthedocs.org'

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -200,7 +200,7 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
                 # it blocks and no exceptions can reach the main program.
                 s3_thread.join(1)
             s3_keys = s3_thread.s3_keys
-        except BaseException as e:
+        except BaseException:
             s3_thread.abort()
             print("Error while pulling data out of PostgreSQL")
             if cleanup_s3:
@@ -209,7 +209,7 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
                     bucket.delete_key(key)
             else:
                 print("Leaving files in place...")
-            raise Exception(e)
+            raise
 
         print("Uploads all done. Cleaning up temp directory " + tmpdir)
         shutil.rmtree(tmpdir)
@@ -323,13 +323,13 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
             try:
                 self.execute(statements)
                 start_idx = end_idx
-            except BaseException as e:
+            except BaseException:
                 # Clean up S3 bucket in the event of any exception
                 if cleanup_s3:
                     print("Error writing to Redshift! Cleaning up S3...")
                     for key in s3_keys:
                         bucket.delete_key(key)
-                raise Exception(e)
+                raise
 
 
 class S3UploaderThread(Thread):

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -200,7 +200,7 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
                 # it blocks and no exceptions can reach the main program.
                 s3_thread.join(1)
             s3_keys = s3_thread.s3_keys
-        finally:
+        except:
             s3_thread.abort()
             print("Error while pulling data out of PostgreSQL")
             if cleanup_s3:
@@ -209,6 +209,7 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
                     bucket.delete_key(key)
             else:
                 print("Leaving files in place...")
+            raise
 
         print("Uploads all done. Cleaning up temp directory " + tmpdir)
         shutil.rmtree(tmpdir)
@@ -322,12 +323,13 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
             try:
                 self.execute(statements)
                 start_idx = end_idx
-            finally:
+            except:
                 # Clean up S3 bucket in the event of any exception
                 if cleanup_s3:
                     print("Error writing to Redshift! Cleaning up S3...")
                     for key in s3_keys:
                         bucket.delete_key(key)
+                raise
 
 
 class S3UploaderThread(Thread):

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -200,7 +200,7 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
                 # it blocks and no exceptions can reach the main program.
                 s3_thread.join(1)
             s3_keys = s3_thread.s3_keys
-        except BaseException:
+        finally:
             s3_thread.abort()
             print("Error while pulling data out of PostgreSQL")
             if cleanup_s3:
@@ -209,7 +209,6 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
                     bucket.delete_key(key)
             else:
                 print("Leaving files in place...")
-            raise
 
         print("Uploads all done. Cleaning up temp directory " + tmpdir)
         shutil.rmtree(tmpdir)
@@ -323,13 +322,12 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
             try:
                 self.execute(statements)
                 start_idx = end_idx
-            except BaseException:
+            finally:
                 # Clean up S3 bucket in the event of any exception
                 if cleanup_s3:
                     print("Error writing to Redshift! Cleaning up S3...")
                     for key in s3_keys:
                         bucket.delete_key(key)
-                raise
 
 
 class S3UploaderThread(Thread):

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -200,16 +200,16 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
                 # it blocks and no exceptions can reach the main program.
                 s3_thread.join(1)
             s3_keys = s3_thread.s3_keys
-        except:
+        except BaseException as e:
             s3_thread.abort()
-            print("Error while pulling data out of PostgreSQL.")
+            print("Error while pulling data out of PostgreSQL")
             if cleanup_s3:
                 print("Cleaning up S3...")
                 for key in s3_thread.s3_keys:
                     bucket.delete_key(key)
             else:
                 print("Leaving files in place...")
-            raise
+            raise Exception(e)
 
         print("Uploads all done. Cleaning up temp directory " + tmpdir)
         shutil.rmtree(tmpdir)
@@ -323,13 +323,13 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
             try:
                 self.execute(statements)
                 start_idx = end_idx
-            except:
+            except BaseException as e:
                 # Clean up S3 bucket in the event of any exception
                 if cleanup_s3:
                     print("Error writing to Redshift! Cleaning up S3...")
                     for key in s3_keys:
                         bucket.delete_key(key)
-                raise
+                raise Exception(e)
 
 
 class S3UploaderThread(Thread):


### PR DESCRIPTION
Should users want to not load their data into a Redshift cluster, but rather use Redshift Spectrum to query the data directly from S3 we should split out that into it's own method to make it possible. 

This is a copy paste of the copy to s3 parts of `copy_table_to_redshift` into it's own method, then used in `copy_table_to_redshift`. 