### PR TITLE
correct `analyze_compression` argument in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ altering the reflected :class:`~sqlalchemy.schema.Table`::
   INSERT INTO my_schema.my_table SELECT * from my_schema.my_table$outgoing;
   DROP TABLE my_schema.my_table$outgoing;
 
-If you pass ``analyze_compress=True`` to `deep_copy`, compression encodings
+If you pass ``analyze_compression=True`` to `deep_copy`, compression encodings
 will be updated in the resultant table based on results of running
 ANALYZE COMPRESSION to determine optimal encodings for the existing data.
 


### PR DESCRIPTION
The parameter seems to be named [`analyze_compression`](https://github.com/SimpleFinance/shiftmanager/blob/3b957b1eb3162da213ce2aa721bd49e7faf437e3/shiftmanager/mixins/reflection.py#L240), not `analyze_compress`.

This tripped me up until I finally read through the source code directly- hopefully a fix to the `README` will save others from similar confusion.