### PR TITLE
allow unload to be filtered with where clause

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.6.9'
+version = '0.6.10'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis',
            'Allison Keene', 'Xavier Stevens', 'KF Fellows',

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -420,7 +420,7 @@ class S3Mixin(object):
 
     @check_s3_connection
     def unload_table_to_s3(self, bucket, keypath, table, col_str='*',
-                           to_json=True, options=None):
+                           where=None, to_json=True, options=None):
         """
         Given a table in Redshift, UNLOAD it to S3
 
@@ -435,6 +435,9 @@ class S3Mixin(object):
         col_str : str
             Comma separated string of columns to unload
             Defaults to '*'
+        where : str
+            SQL where clause string to filter select statement in unload
+            Defaults to None
         to_json: boolean
             Defaults to True
         options : str
@@ -464,13 +467,18 @@ class S3Mixin(object):
         else:
             cols = col_str
 
+        select = "SELECT {col_str} FROM {table} ".format(
+            col_str=cols, table=table)
+        if where:
+            select += where
+
         statement = """
-        UNLOAD ($$SELECT {col_str} FROM {table}$$)
+        UNLOAD ($$ {select} $$)
         TO '{s3_path}'
         CREDENTIALS '{creds}'
         {options};
-        """.format(table=table, col_str=cols, s3_path=s3_table_path,
-                   creds=creds, options=options)
+        """.format(select=select.strip(), s3_path=s3_table_path, creds=creds,
+                   options=options)
 
         print("Performing UNLOAD...")
         self.execute(statement)

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -437,7 +437,7 @@ class S3Mixin(object):
             Defaults to '*'
         where : str
             SQL where clause string to filter select statement in unload
-            Defaults to None
+            Defaults to None, meaning no WHERE clause is applied
         to_json: boolean
             Defaults to True
         options : str
@@ -469,11 +469,11 @@ class S3Mixin(object):
 
         select = "SELECT {col_str} FROM {table} ".format(
             col_str=cols, table=table)
-        if where:
+        if where is not None:
             select += where
 
         statement = """
-        UNLOAD ($$ {select} $$)
+        UNLOAD ($${select}$$)
         TO '{s3_path}'
         CREDENTIALS '{creds}'
         {options};

--- a/shiftmanager/tests/test_s3.py
+++ b/shiftmanager/tests/test_s3.py
@@ -218,7 +218,7 @@ def test_unload_table_to_s3(shift):
     expect_options = "MANIFEST GZIP ESCAPE ALLOWOVERWRITE"
 
     expected = """
-    UNLOAD ($$ SELECT {col_str} FROM {table} $$)
+    UNLOAD ($$SELECT {col_str} FROM {table}$$)
     TO '{s3_path}'
     CREDENTIALS '{creds}'
     {options};

--- a/shiftmanager/tests/test_s3.py
+++ b/shiftmanager/tests/test_s3.py
@@ -218,7 +218,7 @@ def test_unload_table_to_s3(shift):
     expect_options = "MANIFEST GZIP ESCAPE ALLOWOVERWRITE"
 
     expected = """
-    UNLOAD ($$SELECT {col_str} FROM {table}$$)
+    UNLOAD ($$ SELECT {col_str} FROM {table} $$)
     TO '{s3_path}'
     CREDENTIALS '{creds}'
     {options};


### PR DESCRIPTION
We should allow the `unload` method to be filtered by a user provided SQL where clause. 