### PR TITLE
unload with parallel off when distytle all

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.6.10'
+version = '0.6.11'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis',
            'Allison Keene', 'Xavier Stevens', 'KF Fellows',


### PR DESCRIPTION
When unloading a table with `diststyle all` we should turn off parallel so the table is unloaded to avoid dumping a bunch of empty files from slices without and of the table. 