### PR TITLE
Set canned_acl on manifest files

### DIFF
--- a/shiftmanager/metadata.py
+++ b/shiftmanager/metadata.py
@@ -9,7 +9,7 @@ Information describing the project.
 package = 'shiftmanager'
 project = 'shiftmanager'
 project_no_spaces = project.replace(' ', '')
-version = '0.6.12'
+version = '0.7.0'
 description = 'Management tools for Amazon Redshift'
 authors = ['Jeff Klukas', 'Rob Story', 'Meli Lewis',
            'Allison Keene', 'Xavier Stevens', 'KF Fellows',

--- a/shiftmanager/mixins/postgres.py
+++ b/shiftmanager/mixins/postgres.py
@@ -307,7 +307,7 @@ libpq-connect.html#LIBPQ-PARAMKEYWORDS
 
             print('Writing .manifest file to S3...')
             self.write_string_to_s3(json.dumps(manifest), bucket,
-                                    manifest_key_path)
+                                    manifest_key_path, canned_acl=canned_acl)
             complete_manifest_path = "".join(['s3://', bucket.name,
                                               manifest_key_path])
             statements = ""

--- a/shiftmanager/mixins/s3.py
+++ b/shiftmanager/mixins/s3.py
@@ -131,7 +131,7 @@ class S3Mixin(object):
             key.close()
         return key
 
-    def write_string_to_s3(self, chunk, bucket, s3_key_path):
+    def write_string_to_s3(self, chunk, bucket, s3_key_path, canned_acl=None):
         """
         Given a string chunk that represents a piece of a CSV file, write
         the chunk to an S3 key.
@@ -147,6 +147,8 @@ class S3Mixin(object):
         """
         boto_key = bucket.new_key(s3_key_path)
         boto_key.set_contents_from_string(chunk, encrypt_key=True)
+        if canned_acl:
+            boto_key.set_canned_acl(canned_acl)
 
     def write_file_to_s3(self, f, bucket, s3_key_path):
         """


### PR DESCRIPTION
Setting the canned_acl on the data files is nice but if it's not on the
manifest file then it doesn't do much good unless the same user is
writing and reading both. In some situations we have an individual IAM
user writing to S3 but using a shared role to read during the COPY
(using set_aws_role). This makes sure that the manifests are always
readable across accounts.